### PR TITLE
Adds CapybaraExtensions.extension_methods

### DIFF
--- a/lib/capybara-extensions.rb
+++ b/lib/capybara-extensions.rb
@@ -2,14 +2,16 @@ require 'capybara'
 require 'capybara_minitest_spec'
 
 module CapybaraExtensions
-  ExtensionMethods = []
+  def self.extension_methods
+    (CapybaraExtensions::Finders.instance_methods + CapybaraExtensions::Matchers.instance_methods - Object.instance_methods).uniq
+  end
 end
 
 require 'capybara-extensions/finders'
 require 'capybara-extensions/matchers'
 
 module Capybara::DSL
-  CapybaraExtensions::ExtensionMethods.each do |method|
+  CapybaraExtensions.extension_methods.each do |method|
     define_method method do |*args, &block|
       page.send method, *args, &block
     end
@@ -17,7 +19,7 @@ module Capybara::DSL
 end
 
 class Capybara::Session
-  CapybaraExtensions::ExtensionMethods.each do |method|
+  CapybaraExtensions::extension_methods.each do |method|
     define_method method do |*args, &block|
       current_scope.send method, *args, &block
     end

--- a/lib/capybara-extensions/finders.rb
+++ b/lib/capybara-extensions/finders.rb
@@ -2,7 +2,6 @@ require_relative 'locators'
 
 module CapybaraExtensions::Finders
   include CapybaraExtensions::Locators
-  CapybaraExtensions::ExtensionMethods.concat [:find_article, :find_aside, :find_footer, :find_form, :find_header, :find_list_item, :find_navigation, :find_ordered_list, :find_paragraph, :find_row, :find_section, :find_table, :find_unordered_list, :first_article, :first_aside, :first_footer, :first_form, :first_header, :first_navigation, :first_ordered_list, :first_paragraph, :first_row, :first_section, :first_table, :first_unordered_list, :list_item_number, :row_number]
 
   # Find an HTML article based on the given arguments.
   #

--- a/lib/capybara-extensions/matchers.rb
+++ b/lib/capybara-extensions/matchers.rb
@@ -2,7 +2,6 @@ require_relative 'locators'
 
 module CapybaraExtensions::Matchers
   include CapybaraExtensions::Locators
-  CapybaraExtensions::ExtensionMethods.concat [:has_field_value?, :has_no_field_value?, :has_image?, :has_no_image?, :has_meta_tag?, :has_no_meta_tag?]
 
   # Checks that the current node has an image with the given src or alt.
   #


### PR DESCRIPTION
Adds CapybaraExtensions.extension_methods instead of concatenating a list of Finders and Methods.
