### PR TITLE
Don't use native nodes to get attributes

### DIFF
--- a/lib/capybara-extensions/locators.rb
+++ b/lib/capybara-extensions/locators.rb
@@ -39,10 +39,10 @@ module CapybaraExtensions::Locators
   def _find_image_with_regex(src)
     all_images = all('img')
     all_images.each do |image|
-      if image.native.attributes['src'].value.match(src).nil?
+      if image['src'].match(src).nil?
         return nil
       else
-        return image.native.attributes['src'].value
+        return image['src']
       end
     end
   end


### PR DESCRIPTION
In Poltergeist v1.11.0 calling attributes['src'] returns a Ruby string and not an object with a `value` method.  This caused using a regex to find an image by source to throw the following error. 

```
NoMethodError: undefined method `value' for #<String:0x007fb5d8a12af8>
```

Capybara has a driver agnostic way of retrieving attributes from elements, this switches to using the Capybara method.