### PR TITLE
Check all images when searching by regex

### DIFF
--- a/lib/capybara-extensions/locators.rb
+++ b/lib/capybara-extensions/locators.rb
@@ -40,10 +40,9 @@ module CapybaraExtensions::Locators
     all_images = all('img')
     all_images.each do |image|
       if image.native.attributes['src'].value.match(src).nil?
-        return nil
-      else
         return image.native.attributes['src'].value
       end
     end
+    nil
   end
 end


### PR DESCRIPTION
The current implementation of `_find_image_with_regex` only checks the first image on the page.  This makes sure we don't exit the loop early.